### PR TITLE
Add missing google_client_config data source

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,6 @@
+data "google_client_config" "provider" {
+}
+
 data "google_project" "project" {
   project_id = var.project_id
 }


### PR DESCRIPTION
This pull request includes a small change to the `providers.tf` file. The change adds a new data block for `google_client_config` to the configuration.