### PR TITLE
Add lifecycle ignore changes to vcenter folder due to bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ resource "google_gkeonprem_vmware_cluster" "cluster" {
       vcenter[0].cluster,
       vcenter[0].datacenter,
       vcenter[0].datastore,
+      vcenter[0].folder,
       dataplane_v2
     ]
   }


### PR DESCRIPTION
This pull request includes a small change to the `main.tf` file. The change adds a new attribute, `vcenter[0].folder`, to the list of vCenter parameters in the `google_gkeonprem_vmware_cluster` resource due to bug explained [here](https://cloud.google.com/kubernetes-engine/distributed-cloud/vmware/docs/troubleshooting/known-issues#terraform-removes-vcenter-fields-unexpectedly)

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR104): Added `vcenter[0].folder` to the list of vCenter parameters in the `google_gkeonprem_vmware_cluster` resource.