### PR TITLE
change depends on to node_pool

### DIFF
--- a/connect-gateway-rbac.tf
+++ b/connect-gateway-rbac.tf
@@ -8,6 +8,6 @@ resource "helm_release" "connect_gateway_rbac" {
     name  = "connectGatewayUsers"
     value = var.connect_gateway_users
   }]
-  depends_on = [google_gkeonprem_vmware_cluster.cluster]
+  depends_on = [google_gkeonprem_vmware_node_pool.node_pool]
 }
 


### PR DESCRIPTION
This pull request includes a change to the `connect-gateway-rbac.tf` file to update the dependency for the `helm_release` resource.

Dependency update:

* [`connect-gateway-rbac.tf`](diffhunk://#diff-64eac6a86eb8a679daa1c10bfc62944ae327f6dd3a0a5b1c8aa29eb8a26e756eL11-R11): Changed the `depends_on` attribute from `google_gkeonprem_vmware_cluster.cluster` to `google_gkeonprem_vmware_node_pool.node_pool` for the `helm_release` resource `connect_gateway_rbac`.