### PR TITLE
add condition to only create if not empty list

### DIFF
--- a/connect-gateway-rbac.tf
+++ b/connect-gateway-rbac.tf
@@ -1,4 +1,5 @@
 resource "helm_release" "connect_gateway_rbac" {
+  count     = length(var.connect_gateway_users) > 0 ? 1 : 0
   name      = "connect-gateway-rbac"
   namespace = "gke-connect"
   chart     = "${path.module}/connect-gateway-rbac"


### PR DESCRIPTION
This pull request includes a small change to the `connect-gateway-rbac.tf` file. The change ensures that the Helm release for `connect_gateway_rbac` is only created if there are users specified in the `connect_gateway_users` variable.

* [`connect-gateway-rbac.tf`](diffhunk://#diff-64eac6a86eb8a679daa1c10bfc62944ae327f6dd3a0a5b1c8aa29eb8a26e756eR2): Added a conditional count to the `helm_release` resource to check the length of `connect_gateway_users` before creating the release.